### PR TITLE
1.1.1k fips jra disable algos with abort

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1804,9 +1804,11 @@ int speed_main(int argc, char **argv)
     }
 #endif
 #ifndef OPENSSL_NO_DES
-    DES_set_key_unchecked(&key, &sch);
-    DES_set_key_unchecked(&key2, &sch2);
-    DES_set_key_unchecked(&key3, &sch3);
+    if (!FIPS_mode()) {
+        DES_set_key_unchecked(&key, &sch);
+        DES_set_key_unchecked(&key2, &sch2);
+        DES_set_key_unchecked(&key3, &sch3);
+    }
 #endif
     AES_set_encrypt_key(key16, 128, &aes_ks1);
     AES_set_encrypt_key(key24, 192, &aes_ks2);
@@ -1820,37 +1822,51 @@ int speed_main(int argc, char **argv)
 #endif
 #ifndef OPENSSL_NO_IDEA
     if (doit[D_CBC_IDEA]) {
-        IDEA_set_encrypt_key(key16, &idea_ks);
+        if (!FIPS_mode()) {
+            IDEA_set_encrypt_key(key16, &idea_ks);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_SEED
     if (doit[D_CBC_SEED]) {
-        SEED_set_key(key16, &seed_ks);
+        if (!FIPS_mode()) {
+            SEED_set_key(key16, &seed_ks);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_RC4
    if (doit[D_RC4]) {
-        RC4_set_key(&rc4_ks, 16, key16);
+        if (!FIPS_mode()) {
+            RC4_set_key(&rc4_ks, 16, key16);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_RC2
     if (doit[D_CBC_RC2]) {
-        RC2_set_key(&rc2_ks, 16, key16, 128);
+        if (!FIPS_mode()) {
+            RC2_set_key(&rc2_ks, 16, key16, 128);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_RC5
     if (doit[D_CBC_RC5]) {
-        RC5_32_set_key(&rc5_ks, 16, key16, 12);
+        if (!FIPS_mode()) {
+            RC5_32_set_key(&rc5_ks, 16, key16, 12);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_BF
     if (doit[D_CBC_BF]) {
-        BF_set_key(&bf_ks, 16, key16);
+        if (!FIPS_mode()) {
+            BF_set_key(&bf_ks, 16, key16);
+        }
     }
 #endif
 #ifndef OPENSSL_NO_CAST
     if (doit[D_CBC_CAST]) {
-        CAST_set_key(&cast_ks, 16, key16);
+        if (!FIPS_mode()) {
+            CAST_set_key(&cast_ks, 16, key16);
+        }
     }
 #endif
 #ifndef SIGALRM
@@ -2096,6 +2112,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_MD2
     if (doit[D_MD2]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_md2()==NULL)
+                break;
             print_message(names[D_MD2], c[D_MD2][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2108,6 +2126,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_MDC2
     if (doit[D_MDC2]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_mdc2()==NULL)
+                break;
             print_message(names[D_MDC2], c[D_MDC2][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2121,6 +2141,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_MD4
     if (doit[D_MD4]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_md4()==NULL)
+                break;
             print_message(names[D_MD4], c[D_MD4][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2134,6 +2156,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_MD5
     if (doit[D_MD5]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_md5()==NULL)
+                break;
             print_message(names[D_MD5], c[D_MD5][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2148,6 +2172,8 @@ int speed_main(int argc, char **argv)
         int len = strlen(hmac_key);
 
         for (i = 0; i < loopargs_len; i++) {
+            if (EVP_md5()==NULL)
+                break;
             loopargs[i].hctx = HMAC_CTX_new();
             HMAC_CTX_set_flags(loopargs[i].hctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
             if (loopargs[i].hctx == NULL) {
@@ -2158,6 +2184,8 @@ int speed_main(int argc, char **argv)
             HMAC_Init_ex(loopargs[i].hctx, hmac_key, len, EVP_md5(), NULL);
         }
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_md5()==NULL)
+                break;
             print_message(names[D_HMAC], c[D_HMAC][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2166,12 +2194,16 @@ int speed_main(int argc, char **argv)
             print_result(D_HMAC, testnum, count, d);
         }
         for (i = 0; i < loopargs_len; i++) {
+            if (EVP_md5()==NULL)
+                break;
             HMAC_CTX_free(loopargs[i].hctx);
         }
     }
 #endif
     if (doit[D_SHA1]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_sha1()==NULL)
+                break;
             print_message(names[D_SHA1], c[D_SHA1][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2203,6 +2235,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_WHIRLPOOL
     if (doit[D_WHIRLPOOL]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_WHIRLPOOL], c[D_WHIRLPOOL][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2216,6 +2250,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_RMD160
     if (doit[D_RMD160]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_ripemd160()==NULL)
+                break;
             print_message(names[D_RMD160], c[D_RMD160][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2228,6 +2264,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_RC4
     if (doit[D_RC4]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (EVP_rc4()==NULL)
+                break;
             print_message(names[D_RC4], c[D_RC4][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
@@ -2240,6 +2278,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DES
     if (doit[D_CBC_DES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_DES], c[D_CBC_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2251,6 +2291,8 @@ int speed_main(int argc, char **argv)
 
     if (doit[D_EDE3_DES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_EDE3_DES], c[D_EDE3_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2298,6 +2340,8 @@ int speed_main(int argc, char **argv)
 
     if (doit[D_IGE_128_AES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_IGE_128_AES], c[D_IGE_128_AES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2309,6 +2353,8 @@ int speed_main(int argc, char **argv)
     }
     if (doit[D_IGE_192_AES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_IGE_192_AES], c[D_IGE_192_AES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2320,6 +2366,8 @@ int speed_main(int argc, char **argv)
     }
     if (doit[D_IGE_256_AES]) {
         for (testnum = 0; testnum < size_num; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_IGE_256_AES], c[D_IGE_256_AES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2356,6 +2404,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_128_CML] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_128_CML], c[D_CBC_128_CML][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2374,6 +2424,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_192_CML] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_192_CML], c[D_CBC_192_CML][testnum],
                           lengths[testnum], seconds.sym);
             if (async_jobs > 0) {
@@ -2396,6 +2448,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_256_CML] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_256_CML], c[D_CBC_256_CML][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2416,6 +2470,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_IDEA] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_IDEA], c[D_CBC_IDEA][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2436,6 +2492,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_SEED] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_SEED], c[D_CBC_SEED][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2455,6 +2513,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_RC2] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_RC2], c[D_CBC_RC2][testnum],
                           lengths[testnum], seconds.sym);
             if (async_jobs > 0) {
@@ -2479,6 +2539,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_RC5] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_RC5], c[D_CBC_RC5][testnum],
                           lengths[testnum], seconds.sym);
             if (async_jobs > 0) {
@@ -2503,6 +2565,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_BF] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_BF], c[D_CBC_BF][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2523,6 +2587,8 @@ int speed_main(int argc, char **argv)
             doit[D_CBC_CAST] = 0;
         }
         for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
+            if (FIPS_mode())
+                break;
             print_message(names[D_CBC_CAST], c[D_CBC_CAST][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2727,6 +2793,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DSA
     for (testnum = 0; testnum < DSA_NUM; testnum++) {
         int st = 0;
+        if (FIPS_mode())
+            break;
         if (!dsa_doit[testnum])
             continue;
 
@@ -3183,7 +3251,16 @@ int speed_main(int argc, char **argv)
     }
 
     for (k = 0; k < ALGOR_NUM; k++) {
+        int allzeros = 1;
         if (!doit[k])
+            continue;
+        for (testnum = 0; testnum < size_num; testnum++) {
+            if (results[k][testnum] != 0) {
+                allzeros = 0;
+                break;
+            }
+        }
+        if (allzeros)
             continue;
         if (mr)
             printf("+F:%u:%s", k, names[k]);
@@ -3218,6 +3295,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DSA
     testnum = 1;
     for (k = 0; k < DSA_NUM; k++) {
+        if (FIPS_mode())
+            break;
         if (!dsa_doit[k])
             continue;
         if (testnum && !mr) {

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 
 #include <openssl/aes.h>
@@ -44,6 +51,12 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
 {
     size_t n;
     size_t len = length;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (length == 0)
         return;
@@ -183,6 +196,12 @@ void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char prev[AES_BLOCK_SIZE];
     const unsigned char *iv;
     const unsigned char *iv2;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     OPENSSL_assert(in && out && key && ivec);
     OPENSSL_assert((AES_ENCRYPT == enc) || (AES_DECRYPT == enc));

--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -19,6 +19,14 @@
  */
 
 #include <openssl/e_os2.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "crypto/aria.h"
 
 #include <assert.h>
@@ -475,6 +483,12 @@ void aria_encrypt(const unsigned char *in, unsigned char *out,
     int Nr;
     const ARIA_u128 *rk;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     if (in == NULL || out == NULL || key == NULL) {
         return;
     }
@@ -544,6 +558,11 @@ int aria_set_encrypt_key(const unsigned char *userKey, const int bits,
 
     ARIA_u128 *rk;
     int Nr = (bits + 256) / 32;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -1;
+    }
 
     if (userKey == NULL || key == NULL) {
         return -1;
@@ -677,6 +696,11 @@ int aria_set_decrypt_key(const unsigned char *userKey, const int bits,
     uint32_t s0, s1, s2, s3;
 
     const int r = aria_set_encrypt_key(userKey, bits, key);
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -1;
+    }
 
     if (r != 0) {
         return r;
@@ -1110,6 +1134,13 @@ void aria_encrypt(const unsigned char *in, unsigned char *out,
                   const ARIA_KEY *key)
 {
     assert(in != NULL && out != NULL && key != NULL);
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     do_encrypt(out, in, key->rounds, key->rd_key);
 }
 
@@ -1124,6 +1155,11 @@ int aria_set_encrypt_key(const unsigned char *userKey, const int bits,
 {
     const ARIA_u128 *ck1, *ck2, *ck3;
     ARIA_u128 kr, w0, w1, w2, w3;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -1;
+    }
 
     if (!userKey || !key)
         return -1;
@@ -1198,6 +1234,11 @@ int aria_set_decrypt_key(const unsigned char *userKey, const int bits,
     ARIA_KEY ek;
     const int r = aria_set_encrypt_key(userKey, bits, &ek);
     unsigned int i, rounds = ek.rounds;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -1;
+    }
 
     if (r == 0) {
         key->rounds = rounds;

--- a/crypto/asn1/standard_methods.h
+++ b/crypto/asn1/standard_methods.h
@@ -59,3 +59,61 @@ static const EVP_PKEY_ASN1_METHOD *standard_methods[] = {
 #endif
 };
 
+static const EVP_PKEY_ASN1_METHOD *standard_methods_fips[] = {
+#ifndef OPENSSL_NO_RSA
+    &rsa_asn1_meths[0],
+    &rsa_asn1_meths[1],
+#endif
+#ifndef OPENSSL_NO_DH
+    &dh_asn1_meth,
+#endif
+#ifndef OPENSSL_NO_DSA
+#ifndef OPENSSL_FIPS
+    &dsa_asn1_meths[0],
+    &dsa_asn1_meths[1],
+    &dsa_asn1_meths[2],
+    &dsa_asn1_meths[3],
+    &dsa_asn1_meths[4],
+#endif
+#endif
+#ifndef OPENSSL_NO_EC
+    &eckey_asn1_meth,
+#endif
+    &hmac_asn1_meth,
+#ifndef OPENSSL_NO_CMAC
+    &cmac_asn1_meth,
+#endif
+#ifndef OPENSSL_NO_RSA
+    &rsa_pss_asn1_meth,
+#endif
+#ifndef OPENSSL_NO_DH
+    &dhx_asn1_meth,
+#endif
+#ifndef OPENSSL_NO_EC
+#ifndef OPENSSL_FIPS
+    &ecx25519_asn1_meth,
+    &ecx448_asn1_meth,
+#endif
+#endif
+#ifndef OPENSSL_NO_POLY1305
+#ifndef OPENSSL_FIPS
+    &poly1305_asn1_meth,
+#endif
+#endif
+#ifndef OPENSSL_NO_SIPHASH
+#ifndef OPENSSL_FIPS
+    &siphash_asn1_meth,
+#endif
+#endif
+#ifndef OPENSSL_NO_EC
+#ifndef OPENSSL_FIPS
+    &ed25519_asn1_meth,
+    &ed448_asn1_meth,
+#endif
+#endif
+#ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_FIPS
+    &sm2_asn1_meth,
+#endif
+#endif
+};

--- a/crypto/bf/bf_cfb64.c
+++ b/crypto/bf/bf_cfb64.c
@@ -26,6 +26,12 @@ void BF_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     BF_LONG ti[2];
     unsigned char *iv, c, cc;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = (unsigned char *)ivec;
     if (encrypt) {
         while (l--) {

--- a/crypto/bf/bf_ecb.c
+++ b/crypto/bf/bf_ecb.c
@@ -27,6 +27,12 @@ void BF_ecb_encrypt(const unsigned char *in, unsigned char *out,
 {
     BF_LONG l, d[2];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     n2l(in, l);
     d[0] = l;
     n2l(in, l);

--- a/crypto/bf/bf_enc.c
+++ b/crypto/bf/bf_enc.c
@@ -26,6 +26,12 @@ void BF_encrypt(BF_LONG *data, const BF_KEY *key)
     register BF_LONG l, r;
     register const BF_LONG *p, *s;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     p = key->P;
     s = &(key->S[0]);
     l = data[0];
@@ -64,6 +70,12 @@ void BF_decrypt(BF_LONG *data, const BF_KEY *key)
 {
     register BF_LONG l, r;
     register const BF_LONG *p, *s;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     p = key->P;
     s = &(key->S[0]);
@@ -106,6 +118,12 @@ void BF_cbc_encrypt(const unsigned char *in, unsigned char *out, long length,
     register BF_LONG tout0, tout1, xor0, xor1;
     register long l = length;
     BF_LONG tin[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (encrypt) {
         n2l(ivec, tout0);

--- a/crypto/bf/bf_local.h
+++ b/crypto/bf/bf_local.h
@@ -9,7 +9,12 @@
 
 #ifndef OSSL_CRYPTO_BF_LOCAL_H
 # define OSSL_CRYPTO_BF_LOCAL_H
-# include <openssl/opensslconf.h>
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
 
 /* NOTE - c is not incremented as per n2l */
 # define n2ln(c,l1,l2,n) { \

--- a/crypto/bf/bf_ofb64.c
+++ b/crypto/bf/bf_ofb64.c
@@ -28,6 +28,12 @@ void BF_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *iv;
     int save = 0;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = (unsigned char *)ivec;
     n2l(iv, v0);
     n2l(iv, v1);

--- a/crypto/bf/bf_skey.c
+++ b/crypto/bf/bf_skey.c
@@ -19,6 +19,12 @@ void BF_set_key(BF_KEY *key, int len, const unsigned char *data)
     BF_LONG *p, ri, in[2];
     const unsigned char *d, *end;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     memcpy(key, &bf_init, sizeof(BF_KEY));
     p = key->P;
 

--- a/crypto/blake2/blake2b.c
+++ b/crypto/blake2/blake2b.c
@@ -90,6 +90,7 @@ static void blake2b_init_param(BLAKE2B_CTX *S, const BLAKE2B_PARAM *P)
 int BLAKE2b_Init(BLAKE2B_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/blake2/blake2b.c
+++ b/crypto/blake2/blake2b.c
@@ -16,6 +16,14 @@
 
 #include <assert.h>
 #include <string.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 
 #include "blake2_local.h"
@@ -81,6 +89,11 @@ static void blake2b_init_param(BLAKE2B_CTX *S, const BLAKE2B_PARAM *P)
 /* Initialize the hashing context.  Always returns 1. */
 int BLAKE2b_Init(BLAKE2B_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
+
     BLAKE2B_PARAM P[1];
     P->digest_length = BLAKE2B_DIGEST_LENGTH;
     P->key_length    = 0;
@@ -207,6 +220,12 @@ int BLAKE2b_Update(BLAKE2B_CTX *c, const void *data, size_t datalen)
     const uint8_t *in = data;
     size_t fill;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
+
     /*
      * Intuitively one would expect intermediate buffer, c->buf, to
      * store incomplete blocks. But in this case we are interested to
@@ -253,6 +272,12 @@ int BLAKE2b_Update(BLAKE2B_CTX *c, const void *data, size_t datalen)
 int BLAKE2b_Final(unsigned char *md, BLAKE2B_CTX *c)
 {
     int i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     blake2b_set_lastblock(c);
     /* Padding */

--- a/crypto/blake2/blake2s.c
+++ b/crypto/blake2/blake2s.c
@@ -88,6 +88,7 @@ int BLAKE2s_Init(BLAKE2S_CTX *c)
     BLAKE2S_PARAM P[1];
 
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/blake2/blake2s.c
+++ b/crypto/blake2/blake2s.c
@@ -16,6 +16,14 @@
 
 #include <assert.h>
 #include <string.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 
 #include "blake2_local.h"
@@ -78,6 +86,11 @@ static void blake2s_init_param(BLAKE2S_CTX *S, const BLAKE2S_PARAM *P)
 int BLAKE2s_Init(BLAKE2S_CTX *c)
 {
     BLAKE2S_PARAM P[1];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
 
     P->digest_length = BLAKE2S_DIGEST_LENGTH;
     P->key_length    = 0;
@@ -201,6 +214,12 @@ int BLAKE2s_Update(BLAKE2S_CTX *c, const void *data, size_t datalen)
     const uint8_t *in = data;
     size_t fill;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
+
     /*
      * Intuitively one would expect intermediate buffer, c->buf, to
      * store incomplete blocks. But in this case we are interested to
@@ -247,6 +266,12 @@ int BLAKE2s_Update(BLAKE2S_CTX *c, const void *data, size_t datalen)
 int BLAKE2s_Final(unsigned char *md, BLAKE2S_CTX *c)
 {
     int i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     blake2s_set_lastblock(c);
     /* Padding */

--- a/crypto/blake2/m_blake2b.c
+++ b/crypto/blake2/m_blake2b.c
@@ -54,6 +54,10 @@ static const EVP_MD blake2b_md = {
 
 const EVP_MD *EVP_blake2b512(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &blake2b_md;
 }
 #endif

--- a/crypto/blake2/m_blake2s.c
+++ b/crypto/blake2/m_blake2s.c
@@ -54,6 +54,10 @@ static const EVP_MD blake2s_md = {
 
 const EVP_MD *EVP_blake2s256(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &blake2s_md;
 }
 #endif

--- a/crypto/camellia/camellia.c
+++ b/crypto/camellia/camellia.c
@@ -39,6 +39,13 @@
  * words reasonable performance even with not so modern compilers.
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include "cmll_local.h"
 #include <string.h>
@@ -281,6 +288,12 @@ int Camellia_Ekeygen(int keyBitLength, const u8 *rawKey, KEY_TABLE_TYPE k)
 {
     register u32 s0, s1, s2, s3;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     k[0] = s0 = GETU32(rawKey);
     k[1] = s1 = GETU32(rawKey + 4);
     k[2] = s2 = GETU32(rawKey + 8);
@@ -401,6 +414,12 @@ void Camellia_EncryptBlock_Rounds(int grandRounds, const u8 plaintext[],
     register u32 s0, s1, s2, s3;
     const u32 *k = keyTable, *kend = keyTable + grandRounds * 16;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     s0 = GETU32(plaintext) ^ k[0];
     s1 = GETU32(plaintext + 4) ^ k[1];
     s2 = GETU32(plaintext + 8) ^ k[2];
@@ -443,6 +462,11 @@ void Camellia_EncryptBlock_Rounds(int grandRounds, const u8 plaintext[],
 void Camellia_EncryptBlock(int keyBitLength, const u8 plaintext[],
                            const KEY_TABLE_TYPE keyTable, u8 ciphertext[])
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
     Camellia_EncryptBlock_Rounds(keyBitLength == 128 ? 3 : 4,
                                  plaintext, keyTable, ciphertext);
 }
@@ -453,6 +477,12 @@ void Camellia_DecryptBlock_Rounds(int grandRounds, const u8 ciphertext[],
 {
     u32 s0, s1, s2, s3;
     const u32 *k = keyTable + grandRounds * 16, *kend = keyTable + 4;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     s0 = GETU32(ciphertext) ^ k[0];
     s1 = GETU32(ciphertext + 4) ^ k[1];
@@ -496,6 +526,11 @@ void Camellia_DecryptBlock_Rounds(int grandRounds, const u8 ciphertext[],
 void Camellia_DecryptBlock(int keyBitLength, const u8 plaintext[],
                            const KEY_TABLE_TYPE keyTable, u8 ciphertext[])
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
     Camellia_DecryptBlock_Rounds(keyBitLength == 128 ? 3 : 4,
                                  plaintext, keyTable, ciphertext);
 }

--- a/crypto/camellia/cmll_cbc.c
+++ b/crypto/camellia/cmll_cbc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 
@@ -14,6 +21,11 @@ void Camellia_cbc_encrypt(const unsigned char *in, unsigned char *out,
                           size_t len, const CAMELLIA_KEY *key,
                           unsigned char *ivec, const int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (enc)
         CRYPTO_cbc128_encrypt(in, out, len, key, ivec,

--- a/crypto/camellia/cmll_cfb.c
+++ b/crypto/camellia/cmll_cfb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 
@@ -21,6 +28,12 @@ void Camellia_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                              unsigned char *ivec, int *num, const int enc)
 {
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_cfb128_encrypt(in, out, length, key, ivec, num, enc,
                           (block128_f) Camellia_encrypt);
 }
@@ -30,6 +43,12 @@ void Camellia_cfb1_encrypt(const unsigned char *in, unsigned char *out,
                            size_t length, const CAMELLIA_KEY *key,
                            unsigned char *ivec, int *num, const int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_cfb128_1_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) Camellia_encrypt);
 }
@@ -38,6 +57,12 @@ void Camellia_cfb8_encrypt(const unsigned char *in, unsigned char *out,
                            size_t length, const CAMELLIA_KEY *key,
                            unsigned char *ivec, int *num, const int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_cfb128_8_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) Camellia_encrypt);
 }

--- a/crypto/camellia/cmll_ctr.c
+++ b/crypto/camellia/cmll_ctr.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 
@@ -16,6 +23,11 @@ void Camellia_ctr128_encrypt(const unsigned char *in, unsigned char *out,
                              unsigned char ecount_buf[CAMELLIA_BLOCK_SIZE],
                              unsigned int *num)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     CRYPTO_ctr128_encrypt(in, out, length, key, ivec, ecount_buf, num,
                           (block128_f) Camellia_encrypt);

--- a/crypto/camellia/cmll_ecb.c
+++ b/crypto/camellia/cmll_ecb.c
@@ -7,12 +7,25 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include "cmll_local.h"
 
 void Camellia_ecb_encrypt(const unsigned char *in, unsigned char *out,
                           const CAMELLIA_KEY *key, const int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     if (CAMELLIA_ENCRYPT == enc)
         Camellia_encrypt(in, out, key);
     else

--- a/crypto/camellia/cmll_ofb.c
+++ b/crypto/camellia/cmll_ofb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/camellia.h>
 #include <openssl/modes.h>
 
@@ -19,6 +26,12 @@ void Camellia_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                              size_t length, const CAMELLIA_KEY *key,
                              unsigned char *ivec, int *num)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_ofb128_encrypt(in, out, length, key, ivec, num,
                           (block128_f) Camellia_encrypt);
 }

--- a/crypto/cast/c_cfb64.c
+++ b/crypto/cast/c_cfb64.c
@@ -26,6 +26,12 @@ void CAST_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     CAST_LONG ti[2];
     unsigned char *iv, c, cc;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = ivec;
     if (enc) {
         while (l--) {

--- a/crypto/cast/c_ecb.c
+++ b/crypto/cast/c_ecb.c
@@ -16,6 +16,12 @@ void CAST_ecb_encrypt(const unsigned char *in, unsigned char *out,
 {
     CAST_LONG l, d[2];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     n2l(in, l);
     d[0] = l;
     n2l(in, l);

--- a/crypto/cast/c_enc.c
+++ b/crypto/cast/c_enc.c
@@ -15,6 +15,12 @@ void CAST_encrypt(CAST_LONG *data, const CAST_KEY *key)
     CAST_LONG l, r, t;
     const CAST_LONG *k;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     k = &(key->data[0]);
     l = data[0];
     r = data[1];
@@ -46,6 +52,12 @@ void CAST_decrypt(CAST_LONG *data, const CAST_KEY *key)
 {
     CAST_LONG l, r, t;
     const CAST_LONG *k;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     k = &(key->data[0]);
     l = data[0];
@@ -82,6 +94,12 @@ void CAST_cbc_encrypt(const unsigned char *in, unsigned char *out,
     register CAST_LONG tout0, tout1, xor0, xor1;
     register long l = length;
     CAST_LONG tin[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (enc) {
         n2l(iv, tout0);

--- a/crypto/cast/c_ofb64.c
+++ b/crypto/cast/c_ofb64.c
@@ -28,6 +28,12 @@ void CAST_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *iv;
     int save = 0;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = ivec;
     n2l(iv, v0);
     n2l(iv, v1);

--- a/crypto/cast/c_skey.c
+++ b/crypto/cast/c_skey.c
@@ -32,6 +32,12 @@ void CAST_set_key(CAST_KEY *key, int len, const unsigned char *data)
     CAST_LONG l, *K;
     int i;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     for (i = 0; i < 16; i++)
         x[i] = 0;
     if (len > 16)

--- a/crypto/cast/cast_local.h
+++ b/crypto/cast/cast_local.h
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #ifdef OPENSSL_SYS_WIN32
 # include <stdlib.h>
 #endif

--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -11,6 +11,13 @@
 
 #include <string.h>
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "crypto/chacha.h"
 #include "crypto/ctype.h"
 
@@ -77,6 +84,12 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
     u32 input[16];
     chacha_buf buf;
     size_t todo, i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     /* sigma constant "expand 32-byte k" in little-endian encoding */
     input[0] = ((u32)ossl_toascii('e')) | ((u32)ossl_toascii('x') << 8)

--- a/crypto/des/cbc_cksm.c
+++ b/crypto/des/cbc_cksm.c
@@ -19,6 +19,12 @@ DES_LONG DES_cbc_cksum(const unsigned char *in, DES_cblock *output,
     unsigned char *out = &(*output)[0];
     const unsigned char *iv = &(*ivec)[0];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
+
     c2l(iv, tout0);
     c2l(iv, tout1);
     for (; l > 0; l -= 8) {

--- a/crypto/des/cfb64ede.c
+++ b/crypto/des/cfb64ede.c
@@ -26,6 +26,12 @@ void DES_ede3_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     DES_LONG ti[2];
     unsigned char *iv, c, cc;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = &(*ivec)[0];
     if (enc) {
         while (l--) {
@@ -93,6 +99,12 @@ void DES_ede3_cfb_encrypt(const unsigned char *in, unsigned char *out,
     DES_LONG ti[2];
     unsigned char *iv;
     unsigned char ovec[16];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (num > 64)
         return;

--- a/crypto/des/cfb64enc.c
+++ b/crypto/des/cfb64enc.c
@@ -25,6 +25,12 @@ void DES_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     DES_LONG ti[2];
     unsigned char *iv, c, cc;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = &(*ivec)[0];
     if (enc) {
         while (l--) {

--- a/crypto/des/cfb_enc.c
+++ b/crypto/des/cfb_enc.c
@@ -37,6 +37,12 @@ void DES_cfb_encrypt(const unsigned char *in, unsigned char *out, int numbits,
     unsigned int sh[4];
     unsigned char *ovec = (unsigned char *)sh;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     /* I kind of count that compiler optimizes away this assertion, */
     assert(sizeof(sh[0]) == 4); /* as this holds true for all, */
     /* but 16-bit platforms...      */

--- a/crypto/des/des_enc.c
+++ b/crypto/des/des_enc.c
@@ -16,6 +16,12 @@ void DES_encrypt1(DES_LONG *data, DES_key_schedule *ks, int enc)
     register DES_LONG l, r, t, u;
     register DES_LONG *s;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     r = data[0];
     l = data[1];
 
@@ -87,6 +93,12 @@ void DES_encrypt2(DES_LONG *data, DES_key_schedule *ks, int enc)
     register DES_LONG l, r, t, u;
     register DES_LONG *s;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     r = data[0];
     l = data[1];
 
@@ -151,6 +163,12 @@ void DES_encrypt3(DES_LONG *data, DES_key_schedule *ks1,
 {
     register DES_LONG l, r;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     l = data[0];
     r = data[1];
     IP(l, r);
@@ -170,6 +188,12 @@ void DES_decrypt3(DES_LONG *data, DES_key_schedule *ks1,
                   DES_key_schedule *ks2, DES_key_schedule *ks3)
 {
     register DES_LONG l, r;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     l = data[0];
     r = data[1];
@@ -203,6 +227,12 @@ void DES_ede3_cbc_encrypt(const unsigned char *input, unsigned char *output,
     register long l = length;
     DES_LONG tin[2];
     unsigned char *iv;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     in = input;
     out = output;

--- a/crypto/des/des_local.h
+++ b/crypto/des/des_local.h
@@ -16,6 +16,13 @@
 # include <stdlib.h>
 # include <string.h>
 
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include <openssl/des.h>
 
 # ifdef OPENSSL_BUILD_SHLIBCRYPTO

--- a/crypto/des/ecb3_enc.c
+++ b/crypto/des/ecb3_enc.c
@@ -18,6 +18,12 @@ void DES_ecb3_encrypt(const_DES_cblock *input, DES_cblock *output,
     const unsigned char *in = &(*input)[0];
     unsigned char *out = &(*output)[0];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     c2l(in, l0);
     c2l(in, l1);
     ll[0] = l0;

--- a/crypto/des/ecb_enc.c
+++ b/crypto/des/ecb_enc.c
@@ -35,6 +35,12 @@ void DES_ecb_encrypt(const_DES_cblock *input, DES_cblock *output,
     const unsigned char *in = &(*input)[0];
     unsigned char *out = &(*output)[0];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     c2l(in, l);
     ll[0] = l;
     c2l(in, l);

--- a/crypto/des/fcrypt.c
+++ b/crypto/des/fcrypt.c
@@ -59,6 +59,12 @@ char *DES_crypt(const char *buf, const char *salt)
 {
     static char buff[14];
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return NULL;
+    }
+
 #ifndef CHARSET_EBCDIC
     return DES_fcrypt(buf, salt, buff);
 #else
@@ -98,6 +104,12 @@ char *DES_fcrypt(const char *buf, const char *salt, char *ret)
     unsigned char bb[9];
     unsigned char *b = bb;
     unsigned char c, u;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return NULL;
+    }
 
     x = ret[0] = salt[0];
     if (x == 0 || x >= sizeof(con_salt))

--- a/crypto/des/fcrypt_b.c
+++ b/crypto/des/fcrypt_b.c
@@ -30,6 +30,12 @@ void fcrypt_body(DES_LONG *out, DES_key_schedule *ks, DES_LONG Eswap0,
     register int j;
     register DES_LONG E0, E1;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     l = 0;
     r = 0;
 

--- a/crypto/des/ncbc_enc.c
+++ b/crypto/des/ncbc_enc.c
@@ -30,6 +30,12 @@ void DES_ncbc_encrypt(const unsigned char *in, unsigned char *out,
     DES_LONG tin[2];
     unsigned char *iv;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = &(*ivec)[0];
 
     if (enc) {

--- a/crypto/des/ofb64ede.c
+++ b/crypto/des/ofb64ede.c
@@ -28,6 +28,12 @@ void DES_ede3_ofb64_encrypt(register const unsigned char *in,
     unsigned char *iv;
     int save = 0;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = &(*ivec)[0];
     c2l(iv, v0);
     c2l(iv, v1);

--- a/crypto/des/ofb64enc.c
+++ b/crypto/des/ofb64enc.c
@@ -27,6 +27,12 @@ void DES_ofb64_encrypt(register const unsigned char *in,
     unsigned char *iv;
     int save = 0;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     iv = &(*ivec)[0];
     c2l(iv, v0);
     c2l(iv, v1);

--- a/crypto/des/ofb_enc.c
+++ b/crypto/des/ofb_enc.c
@@ -26,6 +26,12 @@ void DES_ofb_encrypt(const unsigned char *in, unsigned char *out, int numbits,
     DES_LONG ti[2];
     unsigned char *iv;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     if (num > 64)
         return;
     if (num > 32) {

--- a/crypto/des/pcbc_enc.c
+++ b/crypto/des/pcbc_enc.c
@@ -18,6 +18,12 @@ void DES_pcbc_encrypt(const unsigned char *input, unsigned char *output,
     const unsigned char *in;
     unsigned char *out, *iv;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     in = input;
     out = output;
     iv = &(*ivec)[0];

--- a/crypto/des/rand_key.c
+++ b/crypto/des/rand_key.c
@@ -7,11 +7,23 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/des.h>
 #include <openssl/rand.h>
 
 int DES_random_key(DES_cblock *ret)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
+
     do {
         if (RAND_priv_bytes((unsigned char *)ret, sizeof(DES_cblock)) != 1)
             return 0;

--- a/crypto/des/set_key.c
+++ b/crypto/des/set_key.c
@@ -277,6 +277,11 @@ static const DES_LONG des_skb[8][64] = {
 
 int DES_set_key(const_DES_cblock *key, DES_key_schedule *schedule)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -2;
+    }
+
     if (DES_check_key) {
         return DES_set_key_checked(key, schedule);
     } else {
@@ -292,6 +297,11 @@ int DES_set_key(const_DES_cblock *key, DES_key_schedule *schedule)
  */
 int DES_set_key_checked(const_DES_cblock *key, DES_key_schedule *schedule)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return -2;
+    }
+
     if (!DES_check_key_parity(key))
         return -1;
     if (DES_is_weak_key(key))
@@ -308,6 +318,12 @@ void DES_set_key_unchecked(const_DES_cblock *key, DES_key_schedule *schedule)
     register const unsigned char *in;
     register DES_LONG *k;
     register int i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
 #ifdef OPENBSD_DEV_CRYPTO
     memcpy(schedule->key, key, sizeof(schedule->key));

--- a/crypto/des/xcbc_enc.c
+++ b/crypto/des/xcbc_enc.c
@@ -24,6 +24,12 @@ void DES_xcbc_encrypt(const unsigned char *in, unsigned char *out,
     DES_LONG tin[2];
     unsigned char *iv;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     in2 = &(*inw)[0];
     c2l(in2, inW0);
     c2l(in2, inW1);

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -34,7 +34,7 @@ int DSA_generate_parameters_ex(DSA *ret, int bits,
 # ifdef OPENSSL_FIPS
     if (FIPS_mode()) {
         DSAerr(DSA_F_DSA_GENERATE_PARAMETERS_EX, DSA_R_NON_FIPS_DSA_METHOD);
-        return NULL;
+        return 0;
     }
 
     if (FIPS_mode() && !(ret->meth->flags & DSA_FLAG_FIPS_METHOD)
@@ -662,7 +662,7 @@ int FIPS_dsa_builtin_paramgen2(DSA *ret, size_t L, size_t N,
 {
     if (FIPS_mode()) {
         DSAerr(DSA_F_DSA_BUILTIN_PARAMGEN2, DSA_R_NON_FIPS_DSA_METHOD);
-        return NULL;
+        return 0;
     }
     return dsa_builtin_paramgen2(ret, L, N, evpmd, seed_in, seed_len,
         idx, seed_out, counter_ret, h_ret, cb);

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -52,7 +52,7 @@ int DSA_generate_key(DSA *dsa)
 #ifdef OPENSSL_FIPS
     if (FIPS_mode()) {
         DSAerr(DSA_F_DSA_GENERATE_KEY, DSA_R_NON_FIPS_DSA_METHOD);
-        return NULL;
+        return 0;
     }
 
     if (FIPS_mode() && !(dsa->meth->flags & DSA_FLAG_FIPS_METHOD)
@@ -75,7 +75,7 @@ static int dsa_builtin_keygen(DSA *dsa)
 #ifdef OPENSSL_FIPS
     if (FIPS_mode()) {
         DSAerr(DSA_F_DSA_BUILTIN_KEYGEN, DSA_R_NON_FIPS_DSA_METHOD);
-        return NULL;
+        return 0;
     }
 
     if (FIPS_mode() && !(dsa->flags & DSA_FLAG_NON_FIPS_ALLOW)

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -340,7 +340,7 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
 #ifdef OPENSSL_FIPS
     if (FIPS_mode()) {
         FIPSerr(FIPS_F_DSA_DO_VERIFY, DSA_R_NON_FIPS_DSA_METHOD);
-        return NULL;
+        return -1;
     }
 
     if (FIPS_selftest_failed()) {

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>
 #include <openssl/x509.h>
@@ -274,5 +282,9 @@ const EVP_PKEY_METHOD dsa_pkey_meth = {
 
 const EVP_PKEY_METHOD *dsa_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &dsa_pkey_meth;
 }

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/x509.h>
 #include <openssl/ec.h>
@@ -1465,6 +1473,10 @@ static const EVP_PKEY_METHOD ed448_s390x_pkey_meth = {
 
 const EVP_PKEY_METHOD *ecx25519_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
 #ifdef S390X_EC_ASM
     if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X25519))
         return &ecx25519_s390x_pkey_meth;
@@ -1474,6 +1486,10 @@ const EVP_PKEY_METHOD *ecx25519_pkey_method(void)
 
 const EVP_PKEY_METHOD *ecx448_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
 #ifdef S390X_EC_ASM
     if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_X448))
         return &ecx448_s390x_pkey_meth;
@@ -1483,6 +1499,10 @@ const EVP_PKEY_METHOD *ecx448_pkey_method(void)
 
 const EVP_PKEY_METHOD *ed25519_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
 #ifdef S390X_EC_ASM
     if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED25519)
         && OPENSSL_s390xcap_P.kdsa[0] & S390X_CAPBIT(S390X_EDDSA_SIGN_ED25519)
@@ -1495,6 +1515,10 @@ const EVP_PKEY_METHOD *ed25519_pkey_method(void)
 
 const EVP_PKEY_METHOD *ed448_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
 #ifdef S390X_EC_ASM
     if (OPENSSL_s390xcap_P.pcc[1] & S390X_CAPBIT(S390X_SCALAR_MULTIPLY_ED448)
         && OPENSSL_s390xcap_P.kdsa[0] & S390X_CAPBIT(S390X_EDDSA_SIGN_ED448)

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -7,7 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/opensslconf.h>
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
@@ -2526,6 +2532,25 @@ static const EVP_CIPHER aes_##keylen##_##mode = { \
 const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
 { return &aes_##keylen##_##mode; }
 
+/* Version of BLOCK_CIPHER_custom the disables algorithm in FIPS mode. */
+# define BLOCK_CIPHER_custom_fips(nid,keylen,blocksize,ivlen,mode,MODE,flags) \
+static const EVP_CIPHER aes_##keylen##_##mode = { \
+        nid##_##keylen##_##mode,blocksize, \
+        (EVP_CIPH_##MODE##_MODE==EVP_CIPH_XTS_MODE?2:1)*keylen/8, ivlen, \
+        flags|EVP_CIPH_##MODE##_MODE,   \
+        aes_##mode##_init_key,          \
+        aes_##mode##_cipher,            \
+        aes_##mode##_cleanup,           \
+        sizeof(EVP_AES_##MODE##_CTX),   \
+        NULL,NULL,aes_##mode##_ctrl,NULL }; \
+const EVP_CIPHER *EVP_aes_##keylen##_##mode(void) \
+{ if (FIPS_mode()) { \
+      FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD); \
+      return NULL; \
+  } \
+  return &aes_##keylen##_##mode; }
+
+
 #endif
 
 #if defined(OPENSSL_CPUID_OBJ) && (defined(__arm__) || defined(__arm) || defined(__aarch64__))
@@ -4277,10 +4302,10 @@ static int aes_ocb_cleanup(EVP_CIPHER_CTX *c)
     return 1;
 }
 
-BLOCK_CIPHER_custom(NID_aes, 128, 16, 12, ocb, OCB,
+BLOCK_CIPHER_custom_fips(NID_aes, 128, 16, 12, ocb, OCB,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
-BLOCK_CIPHER_custom(NID_aes, 192, 16, 12, ocb, OCB,
+BLOCK_CIPHER_custom_fips(NID_aes, 192, 16, 12, ocb, OCB,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
-BLOCK_CIPHER_custom(NID_aes, 256, 16, 12, ocb, OCB,
+BLOCK_CIPHER_custom_fips(NID_aes, 256, 16, 12, ocb, OCB,
                     EVP_CIPH_FLAG_AEAD_CIPHER | CUSTOM_FLAGS)
 #endif                         /* OPENSSL_NO_OCB */

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -10,6 +10,7 @@
 
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_ARIA
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/modes.h>
 # include <openssl/rand.h>

--- a/crypto/evp/e_bf.c
+++ b/crypto/evp/e_bf.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_BF
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include "crypto/evp.h"
 # include <openssl/objects.h>

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -182,7 +182,12 @@ static const EVP_CIPHER camellia_##keylen##_##mode = { \
         sizeof(EVP_CAMELLIA_KEY),       \
         NULL,NULL,NULL,NULL }; \
 const EVP_CIPHER *EVP_camellia_##keylen##_##mode(void) \
-{ return SPARC_CMLL_CAPABLE?&cmll_t4_##keylen##_##mode:&camellia_##keylen##_##mode; }
+{ \
+    if (FIPS_mode()) { \
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD); \
+        return NULL; \
+    } \
+ return SPARC_CMLL_CAPABLE?&cmll_t4_##keylen##_##mode:&camellia_##keylen##_##mode; }
 
 # else
 
@@ -196,7 +201,12 @@ static const EVP_CIPHER camellia_##keylen##_##mode = { \
         sizeof(EVP_CAMELLIA_KEY),       \
         NULL,NULL,NULL,NULL }; \
 const EVP_CIPHER *EVP_camellia_##keylen##_##mode(void) \
-{ return &camellia_##keylen##_##mode; }
+{ \
+    if (FIPS_mode()) { \
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD); \
+        return NULL; \
+    } \
+  return &camellia_##keylen##_##mode; }
 
 # endif
 

--- a/crypto/evp/e_cast.c
+++ b/crypto/evp/e_cast.c
@@ -11,6 +11,7 @@
 #include "internal/cryptlib.h"
 
 #ifndef OPENSSL_NO_CAST
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/objects.h>
 # include "crypto/evp.h"

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -142,6 +142,10 @@ static const EVP_CIPHER chacha20 = {
 
 const EVP_CIPHER *EVP_chacha20(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &chacha20;
 }
 
@@ -631,6 +635,10 @@ static EVP_CIPHER chacha20_poly1305 = {
 
 const EVP_CIPHER *EVP_chacha20_poly1305(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return(&chacha20_poly1305);
 }
 # endif

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_DES
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/objects.h>
 # include "crypto/evp.h"

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_DES
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/objects.h>
 # include "crypto/evp.h"
@@ -302,11 +303,21 @@ static int des3_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 
 const EVP_CIPHER *EVP_des_ede(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
+
     return &des_ede_ecb;
 }
 
 const EVP_CIPHER *EVP_des_ede3(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
+
     return &des_ede3_ecb;
 }
 
@@ -421,6 +432,10 @@ static const EVP_CIPHER des3_wrap = {
 
 const EVP_CIPHER *EVP_des_ede3_wrap(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &des3_wrap;
 }
 

--- a/crypto/evp/e_idea.c
+++ b/crypto/evp/e_idea.c
@@ -11,6 +11,7 @@
 #include "internal/cryptlib.h"
 
 #ifndef OPENSSL_NO_IDEA
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/objects.h>
 # include "crypto/evp.h"

--- a/crypto/evp/e_old.c
+++ b/crypto/evp/e_old.c
@@ -12,6 +12,11 @@
 NON_EMPTY_TRANSLATION_UNIT
 #else
 
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include <openssl/evp.h>
 
 /*
@@ -26,6 +31,10 @@ NON_EMPTY_TRANSLATION_UNIT
 const EVP_CIPHER *EVP_bf_cfb(void);
 const EVP_CIPHER *EVP_bf_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_bf_cfb64();
 }
 # endif
@@ -35,6 +44,10 @@ const EVP_CIPHER *EVP_bf_cfb(void)
 const EVP_CIPHER *EVP_des_cfb(void);
 const EVP_CIPHER *EVP_des_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_des_cfb64();
 }
 
@@ -42,6 +55,10 @@ const EVP_CIPHER *EVP_des_cfb(void)
 const EVP_CIPHER *EVP_des_ede3_cfb(void);
 const EVP_CIPHER *EVP_des_ede3_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_des_ede3_cfb64();
 }
 
@@ -49,6 +66,10 @@ const EVP_CIPHER *EVP_des_ede3_cfb(void)
 const EVP_CIPHER *EVP_des_ede_cfb(void);
 const EVP_CIPHER *EVP_des_ede_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_des_ede_cfb64();
 }
 # endif
@@ -58,6 +79,10 @@ const EVP_CIPHER *EVP_des_ede_cfb(void)
 const EVP_CIPHER *EVP_idea_cfb(void);
 const EVP_CIPHER *EVP_idea_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_idea_cfb64();
 }
 # endif
@@ -67,6 +92,10 @@ const EVP_CIPHER *EVP_idea_cfb(void)
 const EVP_CIPHER *EVP_rc2_cfb(void);
 const EVP_CIPHER *EVP_rc2_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_rc2_cfb64();
 }
 # endif
@@ -76,6 +105,10 @@ const EVP_CIPHER *EVP_rc2_cfb(void)
 const EVP_CIPHER *EVP_cast5_cfb(void);
 const EVP_CIPHER *EVP_cast5_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_cast5_cfb64();
 }
 # endif
@@ -85,6 +118,10 @@ const EVP_CIPHER *EVP_cast5_cfb(void)
 const EVP_CIPHER *EVP_rc5_32_12_16_cfb(void);
 const EVP_CIPHER *EVP_rc5_32_12_16_cfb(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return EVP_rc5_32_12_16_cfb64();
 }
 # endif

--- a/crypto/evp/e_rc2.c
+++ b/crypto/evp/e_rc2.c
@@ -12,6 +12,7 @@
 
 #ifndef OPENSSL_NO_RC2
 
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/objects.h>
 # include "crypto/evp.h"

--- a/crypto/evp/e_rc4.c
+++ b/crypto/evp/e_rc4.c
@@ -58,11 +58,19 @@ static const EVP_CIPHER r4_40_cipher = {
 
 const EVP_CIPHER *EVP_rc4(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &r4_cipher;
 }
 
 const EVP_CIPHER *EVP_rc4_40(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &r4_40_cipher;
 }
 

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -257,6 +257,10 @@ static EVP_CIPHER r4_hmac_md5_cipher = {
 
 const EVP_CIPHER *EVP_rc4_hmac_md5(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &r4_hmac_md5_cipher;
 }
 #endif

--- a/crypto/evp/e_rc5.c
+++ b/crypto/evp/e_rc5.c
@@ -12,6 +12,7 @@
 
 #ifndef OPENSSL_NO_RC5
 
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include "crypto/evp.h"
 # include <openssl/objects.h>

--- a/crypto/evp/e_seed.c
+++ b/crypto/evp/e_seed.c
@@ -11,6 +11,7 @@
 #ifdef OPENSSL_NO_SEED
 NON_EMPTY_TRANSLATION_UNIT
 #else
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/err.h>
 # include <string.h>

--- a/crypto/evp/e_sm4.c
+++ b/crypto/evp/e_sm4.c
@@ -11,6 +11,7 @@
 
 #include "internal/cryptlib.h"
 #ifndef OPENSSL_NO_SM4
+#define FIPS_CIPHER_DISABLE 1
 # include <openssl/evp.h>
 # include <openssl/modes.h>
 # include "crypto/sm4.h"
@@ -94,6 +95,10 @@ static const EVP_CIPHER sm4_ctr_mode = {
 
 const EVP_CIPHER *EVP_sm4_ctr(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &sm4_ctr_mode;
 }
 

--- a/crypto/evp/e_xcbc_d.c
+++ b/crypto/evp/e_xcbc_d.c
@@ -46,6 +46,10 @@ static const EVP_CIPHER d_xcbc_cipher = {
 
 const EVP_CIPHER *EVP_desx_cbc(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &d_xcbc_cipher;
 }
 

--- a/crypto/evp/m_md2.c
+++ b/crypto/evp/m_md2.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
 #ifndef OPENSSL_NO_MD2
 
 # include <openssl/evp.h>
@@ -17,6 +19,11 @@
 # include <openssl/x509.h>
 # include <openssl/md2.h>
 # include <openssl/rsa.h>
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
 
 #include "crypto/evp.h"
 
@@ -51,6 +58,10 @@ static const EVP_MD md2_md = {
 
 const EVP_MD *EVP_md2(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &md2_md;
 }
 #endif

--- a/crypto/evp/m_md4.c
+++ b/crypto/evp/m_md4.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
 #ifndef OPENSSL_NO_MD4
 
 # include <openssl/evp.h>
@@ -17,6 +19,12 @@
 # include <openssl/x509.h>
 # include <openssl/md4.h>
 # include <openssl/rsa.h>
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include "crypto/evp.h"
 
 static int init(EVP_MD_CTX *ctx)
@@ -50,6 +58,10 @@ static const EVP_MD md4_md = {
 
 const EVP_MD *EVP_md4(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &md4_md;
 }
 #endif

--- a/crypto/evp/m_md5.c
+++ b/crypto/evp/m_md5.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
 #ifndef OPENSSL_NO_MD5
 
 # include <openssl/evp.h>
@@ -17,6 +19,12 @@
 # include <openssl/x509.h>
 # include <openssl/md5.h>
 # include <openssl/rsa.h>
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include "crypto/evp.h"
 
 static int init(EVP_MD_CTX *ctx)
@@ -50,6 +58,10 @@ static const EVP_MD md5_md = {
 
 const EVP_MD *EVP_md5(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &md5_md;
 }
 #endif

--- a/crypto/evp/m_md5_sha1.c
+++ b/crypto/evp/m_md5_sha1.c
@@ -137,6 +137,10 @@ static const EVP_MD md5_sha1_md = {
 
 const EVP_MD *EVP_md5_sha1(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &md5_sha1_md;
 }
 #endif

--- a/crypto/evp/m_mdc2.c
+++ b/crypto/evp/m_mdc2.c
@@ -50,6 +50,10 @@ static const EVP_MD mdc2_md = {
 
 const EVP_MD *EVP_mdc2(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &mdc2_md;
 }
 #endif

--- a/crypto/evp/m_ripemd.c
+++ b/crypto/evp/m_ripemd.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
 #ifndef OPENSSL_NO_RMD160
 
 # include <openssl/ripemd.h>
@@ -17,6 +19,12 @@
 # include <openssl/objects.h>
 # include <openssl/x509.h>
 # include <openssl/rsa.h>
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include "crypto/evp.h"
 
 static int init(EVP_MD_CTX *ctx)
@@ -50,6 +58,10 @@ static const EVP_MD ripemd160_md = {
 
 const EVP_MD *EVP_ripemd160(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &ripemd160_md;
 }
 #endif

--- a/crypto/evp/m_sha1.c
+++ b/crypto/evp/m_sha1.c
@@ -10,6 +10,13 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/sha.h>
@@ -108,6 +115,10 @@ static const EVP_MD sha1_md = {
 
 const EVP_MD *EVP_sha1(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &sha1_md;
 }
 

--- a/crypto/evp/m_wp.c
+++ b/crypto/evp/m_wp.c
@@ -49,6 +49,10 @@ static const EVP_MD whirlpool_md = {
 
 const EVP_MD *EVP_whirlpool(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &whirlpool_md;
 }
 #endif

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -35,6 +35,9 @@ int EVP_add_digest(const EVP_MD *md)
     int r;
     const char *name;
 
+    if (md == NULL)
+        return 0;
+
     name = OBJ_nid2sn(md->type);
     r = OBJ_NAME_add(name, OBJ_NAME_TYPE_MD_METH, (const char *)md);
     if (r == 0)

--- a/crypto/fips/fips_kdf_selftest.c
+++ b/crypto/fips/fips_kdf_selftest.c
@@ -16,6 +16,8 @@
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 
+#include "crypto/fips/fips_locl.h"
+
 #ifdef OPENSSL_FIPS
 
 static int FIPS_selftest_tls13(void)
@@ -321,6 +323,7 @@ err:
     return ret;
 }
 
+#if 0
 static int FIPS_selftest_krb5kdf(void)
 {
     int ret = 0;
@@ -361,7 +364,9 @@ err:
     EVP_KDF_CTX_free(kctx);
     return ret;
 }
+#endif
 
+#if 0
 static int FIPS_selftest_sskdf(void)
 {
     int ret = 0;
@@ -409,6 +414,7 @@ err:
     EVP_KDF_CTX_free(kctx);
     return ret;
 }
+#endif
 
 int FIPS_selftest_kdf(void)
 {

--- a/crypto/idea/i_cbc.c
+++ b/crypto/idea/i_cbc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/idea.h>
 #include "idea_local.h"
 
@@ -18,6 +25,12 @@ void IDEA_cbc_encrypt(const unsigned char *in, unsigned char *out,
     register unsigned long tout0, tout1, xor0, xor1;
     register long l = length;
     unsigned long tin[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (encrypt) {
         n2l(iv, tout0);
@@ -90,6 +103,12 @@ void IDEA_encrypt(unsigned long *d, IDEA_KEY_SCHEDULE *key)
 {
     register IDEA_INT *p;
     register unsigned long x1, x2, x3, x4, t0, t1, ul;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     x2 = d[0];
     x1 = (x2 >> 16);

--- a/crypto/idea/i_cfb64.c
+++ b/crypto/idea/i_cfb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/idea.h>
 #include "idea_local.h"
 
@@ -25,6 +32,12 @@ void IDEA_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     if (encrypt) {

--- a/crypto/idea/i_ecb.c
+++ b/crypto/idea/i_ecb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/idea.h>
 #include "idea_local.h"
 #include <openssl/opensslv.h>
@@ -20,6 +27,12 @@ void IDEA_ecb_encrypt(const unsigned char *in, unsigned char *out,
                       IDEA_KEY_SCHEDULE *ks)
 {
     unsigned long l0, l1, d[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     n2l(in, l0);
     d[0] = l0;

--- a/crypto/idea/i_ofb64.c
+++ b/crypto/idea/i_ofb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/idea.h>
 #include "idea_local.h"
 
@@ -27,6 +34,12 @@ void IDEA_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned long ti[2];
     unsigned char *iv;
     int save = 0;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     n2l(iv, v0);

--- a/crypto/idea/i_skey.c
+++ b/crypto/idea/i_skey.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/idea.h>
 #include "idea_local.h"
 
@@ -15,6 +22,12 @@ void IDEA_set_encrypt_key(const unsigned char *key, IDEA_KEY_SCHEDULE *ks)
 {
     int i;
     register IDEA_INT *kt, *kf, r0, r1, r2;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     kt = &(ks->data[0][0]);
     n2s(key, kt[0]);
@@ -55,6 +68,12 @@ void IDEA_set_decrypt_key(IDEA_KEY_SCHEDULE *ek, IDEA_KEY_SCHEDULE *dk)
 {
     int r;
     register IDEA_INT *fp, *tp, t;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     tp = &(dk->data[0][0]);
     fp = &(ek->data[8][0]);

--- a/crypto/kdf/scrypt.c
+++ b/crypto/kdf/scrypt.c
@@ -10,6 +10,14 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/hmac.h>
 #include <openssl/kdf.h>
 #include <openssl/evp.h>
@@ -506,6 +514,10 @@ static int scrypt_alg(const char *pass, size_t passlen,
 
 const EVP_PKEY_METHOD *scrypt_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &scrypt_pkey_meth;
 }
 

--- a/crypto/md2/md2_dgst.c
+++ b/crypto/md2/md2_dgst.c
@@ -78,6 +78,7 @@ const char *MD2_options(void)
 int MD2_Init(MD2_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/md4/md4_dgst.c
+++ b/crypto/md4/md4_dgst.c
@@ -31,6 +31,7 @@
 int MD4_Init(MD4_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/md4/md4_dgst.c
+++ b/crypto/md4/md4_dgst.c
@@ -9,6 +9,14 @@
 
 #include <stdio.h>
 #include <openssl/opensslv.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "md4_local.h"
 
 /*
@@ -22,6 +30,10 @@
 
 int MD4_Init(MD4_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
     memset(c, 0, sizeof(*c));
     c->A = INIT_DATA_A;
     c->B = INIT_DATA_B;

--- a/crypto/md4/md4_local.h
+++ b/crypto/md4/md4_local.h
@@ -31,6 +31,9 @@ void md4_block_data_order(MD4_CTX *c, const void *p, size_t num);
         } while (0)
 #define HASH_BLOCK_DATA_ORDER   md4_block_data_order
 
+/* Don't allow MD4 in FIPS mode. */
+#define FIPS_HASH_DISABLE 1
+
 #include "crypto/md32_common.h"
 
 /*-

--- a/crypto/md5/md5_dgst.c
+++ b/crypto/md5/md5_dgst.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "md5_local.h"
 #include <openssl/opensslv.h>
 
@@ -22,6 +30,10 @@
 
 int MD5_Init(MD5_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
     memset(c, 0, sizeof(*c));
     c->A = INIT_DATA_A;
     c->B = INIT_DATA_B;

--- a/crypto/md5/md5_dgst.c
+++ b/crypto/md5/md5_dgst.c
@@ -31,6 +31,7 @@
 int MD5_Init(MD5_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/md5/md5_local.h
+++ b/crypto/md5/md5_local.h
@@ -42,6 +42,9 @@ void md5_block_data_order(MD5_CTX *c, const void *p, size_t num);
         } while (0)
 #define HASH_BLOCK_DATA_ORDER   md5_block_data_order
 
+/* Don't allow MD5 in FIPS mode. */
+#define FIPS_HASH_DISABLE 1
+
 #include "crypto/md32_common.h"
 
 /*-

--- a/crypto/mdc2/mdc2dgst.c
+++ b/crypto/mdc2/mdc2dgst.c
@@ -10,6 +10,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 #include <openssl/des.h>
 #include <openssl/mdc2.h>
@@ -29,6 +37,11 @@
 static void mdc2_body(MDC2_CTX *c, const unsigned char *in, size_t len);
 int MDC2_Init(MDC2_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
+
     c->num = 0;
     c->pad_type = 1;
     memset(&(c->h[0]), 0x52, MDC2_BLOCK);
@@ -39,6 +52,12 @@ int MDC2_Init(MDC2_CTX *c)
 int MDC2_Update(MDC2_CTX *c, const unsigned char *in, size_t len)
 {
     size_t i, j;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     i = c->num;
     if (i != 0) {
@@ -111,6 +130,12 @@ int MDC2_Final(unsigned char *md, MDC2_CTX *c)
 {
     unsigned int i;
     int j;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     i = c->num;
     j = c->pad_type;

--- a/crypto/mdc2/mdc2dgst.c
+++ b/crypto/mdc2/mdc2dgst.c
@@ -38,6 +38,7 @@ static void mdc2_body(MDC2_CTX *c, const unsigned char *in, size_t len);
 int MDC2_Init(MDC2_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/poly1305/poly1305_base2_44.c
+++ b/crypto/poly1305/poly1305_base2_44.c
@@ -15,6 +15,13 @@
  */
 #include <stdlib.h>
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long u64;
@@ -59,6 +66,11 @@ int poly1305_init(void *ctx, const unsigned char key[16])
     poly1305_internal *st = (poly1305_internal *)ctx;
     u64 r0, r1;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 1;
+    }
+
     /* h = 0 */
     st->h[0] = 0;
     st->h[1] = 0;
@@ -87,6 +99,12 @@ void poly1305_blocks(void *ctx, const unsigned char *inp, size_t len,
     u64 h0, h1, h2, c;
     u128 d0, d1, d2;
     u64 pad = (u64)padbit << 40;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     r0 = st->r[0];
     r1 = st->r[1];
@@ -139,6 +157,12 @@ void poly1305_emit(void *ctx, unsigned char mac[16], const u32 nonce[4])
     u64 g0, g1, g2;
     u128 t;
     u64 mask;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     h0 = st->h[0];
     h1 = st->h[1];

--- a/crypto/poly1305/poly1305_ieee754.c
+++ b/crypto/poly1305/poly1305_ieee754.c
@@ -52,6 +52,13 @@
 
 #include <stdlib.h>
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long long u64;
@@ -111,6 +118,11 @@ int poly1305_init(void *ctx, const unsigned char key[16])
 {
     poly1305_internal *st = (poly1305_internal *) ctx;
     elem64 r0, r1, r2, r3;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 1;
+    }
 
     /* h = 0, biased */
 #if 0
@@ -227,6 +239,12 @@ void poly1305_blocks(void *ctx, const unsigned char *inp, size_t len,
     poly1305_internal *st = (poly1305_internal *)ctx;
     elem64 in0, in1, in2, in3;
     u64 pad = (u64)padbit<<32;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     double x0, x1, x2, x3;
     double h0lo, h0hi, h1lo, h1hi, h2lo, h2hi, h3lo, h3hi;
@@ -434,6 +452,12 @@ void poly1305_emit(void *ctx, unsigned char mac[16], const u32 nonce[4])
     u32 g0, g1, g2, g3, g4;
     u64 t;
     u32 mask;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     /*
      * thanks to bias masking exponent gives integer result

--- a/crypto/poly1305/poly1305_pmeth.c
+++ b/crypto/poly1305/poly1305_pmeth.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
@@ -195,5 +203,10 @@ const EVP_PKEY_METHOD poly1305_pkey_meth = {
 
 const EVP_PKEY_METHOD *poly1305_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
+
     return &poly1305_pkey_meth;
 }

--- a/crypto/rc2/rc2_cbc.c
+++ b/crypto/rc2/rc2_cbc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 
@@ -17,6 +24,12 @@ void RC2_cbc_encrypt(const unsigned char *in, unsigned char *out, long length,
     register unsigned long tout0, tout1, xor0, xor1;
     register long l = length;
     unsigned long tin[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (encrypt) {
         c2l(iv, tout0);
@@ -92,6 +105,12 @@ void RC2_encrypt(unsigned long *d, RC2_KEY *key)
     register RC2_INT x0, x1, x2, x3, t;
     unsigned long l;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     l = d[0];
     x0 = (RC2_INT) l & 0xffff;
     x1 = (RC2_INT) (l >> 16L);
@@ -137,6 +156,12 @@ void RC2_decrypt(unsigned long *d, RC2_KEY *key)
     register RC2_INT *p0, *p1;
     register RC2_INT x0, x1, x2, x3, t;
     unsigned long l;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     l = d[0];
     x0 = (RC2_INT) l & 0xffff;

--- a/crypto/rc2/rc2_ecb.c
+++ b/crypto/rc2/rc2_ecb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 #include <openssl/opensslv.h>
@@ -23,6 +30,12 @@ void RC2_ecb_encrypt(const unsigned char *in, unsigned char *out, RC2_KEY *ks,
                      int encrypt)
 {
     unsigned long l, d[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     c2l(in, l);
     d[0] = l;

--- a/crypto/rc2/rc2_skey.c
+++ b/crypto/rc2/rc2_skey.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 
@@ -52,6 +59,12 @@ void RC2_set_key(RC2_KEY *key, int len, const unsigned char *data, int bits)
     unsigned char *k;
     RC2_INT *ki;
     unsigned int c, d;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     k = (unsigned char *)&(key->data[0]);
     *k = 0;                     /* for if there is a zero length key */

--- a/crypto/rc2/rc2cfb64.c
+++ b/crypto/rc2/rc2cfb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 
@@ -25,6 +32,12 @@ void RC2_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     if (encrypt) {

--- a/crypto/rc2/rc2ofb64.c
+++ b/crypto/rc2/rc2ofb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc2.h>
 #include "rc2_local.h"
 
@@ -27,6 +34,12 @@ void RC2_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned long ti[2];
     unsigned char *iv;
     int save = 0;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     c2l(iv, v0);

--- a/crypto/rc4/rc4_enc.c
+++ b/crypto/rc4/rc4_enc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc4.h>
 #include "rc4_local.h"
 
@@ -24,6 +31,12 @@ void RC4(RC4_KEY *key, size_t len, const unsigned char *indata,
     register RC4_INT *d;
     register RC4_INT x, y, tx, ty;
     size_t i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     x = key->x;
     y = key->y;

--- a/crypto/rc4/rc4_skey.c
+++ b/crypto/rc4/rc4_skey.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc4.h>
 #include "rc4_local.h"
 #include <openssl/opensslv.h>
@@ -33,6 +40,12 @@ void RC4_set_key(RC4_KEY *key, int len, const unsigned char *data)
     register int id1, id2;
     register RC4_INT *d;
     unsigned int i;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     d = &(key->data[0]);
     key->x = 0;

--- a/crypto/rc5/rc5_ecb.c
+++ b/crypto/rc5/rc5_ecb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 #include <openssl/opensslv.h>
@@ -15,6 +22,12 @@ void RC5_32_ecb_encrypt(const unsigned char *in, unsigned char *out,
                         RC5_32_KEY *ks, int encrypt)
 {
     unsigned long l, d[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     c2l(in, l);
     d[0] = l;

--- a/crypto/rc5/rc5_enc.c
+++ b/crypto/rc5/rc5_enc.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 
@@ -19,6 +27,12 @@ void RC5_32_cbc_encrypt(const unsigned char *in, unsigned char *out,
     register unsigned long tout0, tout1, xor0, xor1;
     register long l = length;
     unsigned long tin[2];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if (encrypt) {
         c2l(iv, tout0);
@@ -91,6 +105,12 @@ void RC5_32_encrypt(unsigned long *d, RC5_32_KEY *key)
 {
     RC5_32_INT a, b, *s;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     s = key->data;
 
     a = d[0] + s[0];
@@ -126,6 +146,12 @@ void RC5_32_encrypt(unsigned long *d, RC5_32_KEY *key)
 void RC5_32_decrypt(unsigned long *d, RC5_32_KEY *key)
 {
     RC5_32_INT a, b, *s;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     s = key->data;
 

--- a/crypto/rc5/rc5_skey.c
+++ b/crypto/rc5/rc5_skey.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 
@@ -15,6 +22,12 @@ void RC5_32_set_key(RC5_32_KEY *key, int len, const unsigned char *data,
 {
     RC5_32_INT L[64], l, ll, A, B, *S, k;
     int i, j, m, c, t, ii, jj;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     if ((rounds != RC5_16_ROUNDS) &&
         (rounds != RC5_12_ROUNDS) && (rounds != RC5_8_ROUNDS))

--- a/crypto/rc5/rc5cfb64.c
+++ b/crypto/rc5/rc5cfb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 
@@ -25,6 +32,12 @@ void RC5_32_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     register long l = length;
     unsigned long ti[2];
     unsigned char *iv, c, cc;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     if (encrypt) {

--- a/crypto/rc5/rc5ofb64.c
+++ b/crypto/rc5/rc5ofb64.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/rc5.h>
 #include "rc5_local.h"
 
@@ -27,6 +34,12 @@ void RC5_32_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned long ti[2];
     unsigned char *iv;
     int save = 0;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     iv = (unsigned char *)ivec;
     c2l(iv, v0);

--- a/crypto/ripemd/rmd_dgst.c
+++ b/crypto/ripemd/rmd_dgst.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "rmd_local.h"
 #include <openssl/opensslv.h>
 
@@ -20,6 +28,10 @@ void ripemd160_block(RIPEMD160_CTX *c, unsigned long *p, size_t num);
 
 int RIPEMD160_Init(RIPEMD160_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
     memset(c, 0, sizeof(*c));
     c->A = RIPEMD160_A;
     c->B = RIPEMD160_B;

--- a/crypto/ripemd/rmd_dgst.c
+++ b/crypto/ripemd/rmd_dgst.c
@@ -29,6 +29,7 @@ void ripemd160_block(RIPEMD160_CTX *c, unsigned long *p, size_t num);
 int RIPEMD160_Init(RIPEMD160_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/ripemd/rmd_local.h
+++ b/crypto/ripemd/rmd_local.h
@@ -42,6 +42,9 @@ void ripemd160_block_data_order(RIPEMD160_CTX *c, const void *p, size_t num);
         } while (0)
 #define HASH_BLOCK_DATA_ORDER   ripemd160_block_data_order
 
+/* Don't allow RIPEMD160 in FIPS mode. */
+#define FIPS_HASH_DISABLE 1
+
 #include "crypto/md32_common.h"
 
 /*

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -30,14 +30,6 @@
 #include <openssl/sha.h>
 #include "rsa_local.h"
 
-int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
-                               const unsigned char *from, int flen,
-                               const unsigned char *param, int plen)
-{
-    return ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(to, tlen, from, flen,
-                                                   param, plen, NULL, NULL);
-}
-
 /*
  * Perform the padding as per NIST 800-56B 7.2.2.3
  *      from (K) is the key material.
@@ -128,6 +120,15 @@ int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(unsigned char *to, int tlen,
     OPENSSL_clear_free(dbmask, dbmask_len);
     return rv;
 }
+
+int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
+                               const unsigned char *from, int flen,
+                               const unsigned char *param, int plen)
+{
+    return ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(to, tlen, from, flen,
+                                                   param, plen, NULL, NULL);
+}
+
 
 int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
                                     const unsigned char *from, int flen,

--- a/crypto/seed/seed.c
+++ b/crypto/seed/seed.c
@@ -32,6 +32,14 @@
  * SUCH DAMAGE.
  *
  */
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #ifndef OPENSSL_NO_SEED
 
 # include <stdio.h>
@@ -443,6 +451,12 @@ void SEED_set_key(const unsigned char rawkey[SEED_KEY_LENGTH],
     seed_word x1, x2, x3, x4;
     seed_word t0, t1;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     char2word(rawkey, x1);
     char2word(rawkey + 4, x2);
     char2word(rawkey + 8, x3);
@@ -503,6 +517,12 @@ void SEED_encrypt(const unsigned char s[SEED_BLOCK_SIZE],
     seed_word x1, x2, x3, x4;
     seed_word t0, t1;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     char2word(s, x1);
     char2word(s + 4, x2);
     char2word(s + 8, x3);
@@ -547,6 +567,12 @@ void SEED_decrypt(const unsigned char s[SEED_BLOCK_SIZE],
 {
     seed_word x1, x2, x3, x4;
     seed_word t0, t1;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     char2word(s, x1);
     char2word(s + 4, x2);

--- a/crypto/seed/seed_cbc.c
+++ b/crypto/seed/seed_cbc.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 
@@ -14,6 +21,12 @@ void SEED_cbc_encrypt(const unsigned char *in, unsigned char *out,
                       size_t len, const SEED_KEY_SCHEDULE *ks,
                       unsigned char ivec[SEED_BLOCK_SIZE], int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     if (enc)
         CRYPTO_cbc128_encrypt(in, out, len, ks, ivec,
                               (block128_f) SEED_encrypt);

--- a/crypto/seed/seed_cfb.c
+++ b/crypto/seed/seed_cfb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 
@@ -15,6 +22,12 @@ void SEED_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                          unsigned char ivec[SEED_BLOCK_SIZE], int *num,
                          int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_cfb128_encrypt(in, out, len, ks, ivec, num, enc,
                           (block128_f) SEED_encrypt);
 }

--- a/crypto/seed/seed_ecb.c
+++ b/crypto/seed/seed_ecb.c
@@ -7,11 +7,24 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/seed.h>
 
 void SEED_ecb_encrypt(const unsigned char *in, unsigned char *out,
                       const SEED_KEY_SCHEDULE *ks, int enc)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     if (enc)
         SEED_encrypt(in, out, ks);
     else

--- a/crypto/seed/seed_ofb.c
+++ b/crypto/seed/seed_ofb.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/seed.h>
 #include <openssl/modes.h>
 
@@ -14,6 +21,12 @@ void SEED_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                          size_t len, const SEED_KEY_SCHEDULE *ks,
                          unsigned char ivec[SEED_BLOCK_SIZE], int *num)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     CRYPTO_ofb128_encrypt(in, out, len, ks, ivec, num,
                           (block128_f) SEED_encrypt);
 }

--- a/crypto/sha/sha1_one.c
+++ b/crypto/sha/sha1_one.c
@@ -9,6 +9,14 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
 
@@ -16,6 +24,12 @@ unsigned char *SHA1(const unsigned char *d, size_t n, unsigned char *md)
 {
     SHA_CTX c;
     static unsigned char m[SHA_DIGEST_LENGTH];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return NULL;
+    }
 
     if (md == NULL)
         md = m;

--- a/crypto/sha/sha_local.h
+++ b/crypto/sha/sha_local.h
@@ -62,6 +62,7 @@ void sha1_block_data_order(SHA_CTX *c, const void *p, size_t num);
 int HASH_INIT(SHA_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -125,6 +125,7 @@ int SipHash_Init(SIPHASH *ctx, const unsigned char *k, int crounds, int drounds)
     uint64_t k1 = U8TO64_LE(k + 8);
 
     if (FIPS_mode()) {
+        memset(ctx, 0, sizeof(*ctx));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -25,6 +25,14 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/crypto.h>
 
 #include "crypto/siphash.h"
@@ -116,6 +124,11 @@ int SipHash_Init(SIPHASH *ctx, const unsigned char *k, int crounds, int drounds)
     uint64_t k0 = U8TO64_LE(k);
     uint64_t k1 = U8TO64_LE(k + 8);
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
+
     /* If the hash size wasn't set, i.e. is zero */
     ctx->hash_size = siphash_adjust_hash_size(ctx->hash_size);
 
@@ -151,6 +164,12 @@ void SipHash_Update(SIPHASH *ctx, const unsigned char *in, size_t inlen)
     uint64_t v1 = ctx->v1;
     uint64_t v2 = ctx->v2;
     uint64_t v3 = ctx->v3;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     ctx->total_inlen += inlen;
 
@@ -208,6 +227,12 @@ int SipHash_Final(SIPHASH *ctx, unsigned char *out, size_t outlen)
     uint64_t v1 = ctx->v1;
     uint64_t v2 = ctx->v2;
     uint64_t v3 = ctx->v3;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     if (outlen != (size_t)ctx->hash_size)
         return 0;

--- a/crypto/siphash/siphash_pmeth.c
+++ b/crypto/siphash/siphash_pmeth.c
@@ -8,6 +8,14 @@
  */
 
 #include <stdio.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
@@ -206,5 +214,9 @@ const EVP_PKEY_METHOD siphash_pkey_meth = {
 
 const EVP_PKEY_METHOD *siphash_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &siphash_pkey_meth;
 }

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -9,6 +9,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "crypto/sm2.h"
 #include "crypto/sm2err.h"
 #include "crypto/ec.h" /* ecdh_KDF_X9_63() */
@@ -136,6 +143,12 @@ int sm2_encrypt(const EC_KEY *key,
     /* NULL these before any "goto done" */
     ctext_struct.C2 = NULL;
     ctext_struct.C3 = NULL;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
 
     if (hash == NULL || C3_size <= 0) {
         SM2err(SM2_F_SM2_ENCRYPT, ERR_R_INTERNAL_ERROR);
@@ -282,6 +295,12 @@ int sm2_decrypt(const EC_KEY *key,
     const uint8_t *C3 = NULL;
     int msg_len = 0;
     EVP_MD_CTX *hash = NULL;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
 
     if (field_size == 0 || hash_size <= 0)
        goto done;

--- a/crypto/sm2/sm2_pmeth.c
+++ b/crypto/sm2/sm2_pmeth.c
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/asn1t.h>
 #include <openssl/ec.h>
@@ -330,5 +337,10 @@ const EVP_PKEY_METHOD sm2_pkey_meth = {
 
 const EVP_PKEY_METHOD *sm2_pkey_method(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
+
     return &sm2_pkey_meth;
 }

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -9,6 +9,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "crypto/sm2.h"
 #include "crypto/sm2err.h"
 #include "crypto/ec.h" /* ec_group_do_inverse_ord() */
@@ -45,6 +52,12 @@ int sm2_compute_z_digest(uint8_t *out,
     ctx = BN_CTX_new();
     if (hash == NULL || ctx == NULL) {
         SM2err(SM2_F_SM2_COMPUTE_Z_DIGEST, ERR_R_MALLOC_FAILURE);
+        goto done;
+    }
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
         goto done;
     }
 
@@ -370,6 +383,12 @@ ECDSA_SIG *sm2_do_sign(const EC_KEY *key,
     BIGNUM *e = NULL;
     ECDSA_SIG *sig = NULL;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
+
     e = sm2_compute_msg_hash(digest, key, id, id_len, msg, msg_len);
     if (e == NULL) {
         /* SM2err already called */
@@ -393,6 +412,12 @@ int sm2_do_verify(const EC_KEY *key,
     BIGNUM *e = NULL;
     int ret = 0;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
+
     e = sm2_compute_msg_hash(digest, key, id, id_len, msg, msg_len);
     if (e == NULL) {
         /* SM2err already called */
@@ -413,6 +438,12 @@ int sm2_sign(const unsigned char *dgst, int dgstlen,
     ECDSA_SIG *s = NULL;
     int sigleni;
     int ret = -1;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
 
     e = BN_bin2bn(dgst, dgstlen, NULL);
     if (e == NULL) {
@@ -446,6 +477,12 @@ int sm2_verify(const unsigned char *dgst, int dgstlen,
     unsigned char *der = NULL;
     int derlen = -1;
     int ret = -1;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        goto done;
+    }
 
     s = ECDSA_SIG_new();
     if (s == NULL) {

--- a/crypto/sm3/m_sm3.c
+++ b/crypto/sm3/m_sm3.c
@@ -10,8 +10,16 @@
 
 #include "internal/cryptlib.h"
 
+#include "openssl/opensslconf.h"
+
 #ifndef OPENSSL_NO_SM3
 # include <openssl/evp.h>
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 # include "crypto/evp.h"
 # include "crypto/sm3.h"
 
@@ -46,6 +54,10 @@ static const EVP_MD sm3_md = {
 
 const EVP_MD *EVP_sm3(void)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return NULL;
+    }
     return &sm3_md;
 }
 

--- a/crypto/sm3/sm3.c
+++ b/crypto/sm3/sm3.c
@@ -46,6 +46,12 @@ void sm3_block_data_order(SM3_CTX *ctx, const void *p, size_t num)
     unsigned MD32_REG_T W00, W01, W02, W03, W04, W05, W06, W07,
         W08, W09, W10, W11, W12, W13, W14, W15;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     for (; num--;) {
 
         A = ctx->A;

--- a/crypto/sm3/sm3.c
+++ b/crypto/sm3/sm3.c
@@ -23,6 +23,7 @@
 int sm3_init(SM3_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/sm3/sm3.c
+++ b/crypto/sm3/sm3.c
@@ -10,10 +10,22 @@
  */
 
 #include <openssl/e_os2.h>
+
+#include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "sm3_local.h"
 
 int sm3_init(SM3_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
     memset(c, 0, sizeof(*c));
     c->A = SM3_A;
     c->B = SM3_B;

--- a/crypto/sm3/sm3_local.h
+++ b/crypto/sm3/sm3_local.h
@@ -36,6 +36,9 @@
 
 void sm3_transform(SM3_CTX *c, const unsigned char *data);
 
+/* Don't allow SM3 in FIPS mode. */
+#define FIPS_HASH_DISABLE 1
+
 #include "crypto/md32_common.h"
 
 #define P0(X) (X ^ ROTATE(X, 9) ^ ROTATE(X, 17))

--- a/crypto/sm4/sm4.c
+++ b/crypto/sm4/sm4.c
@@ -10,6 +10,14 @@
  */
 
 #include <openssl/e_os2.h>
+
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include "crypto/sm4.h"
 
 static const uint8_t SM4_S[256] = {
@@ -154,6 +162,11 @@ int SM4_set_key(const uint8_t *key, SM4_KEY *ks)
     uint32_t K[4];
     int i;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
+
     K[0] = load_u32_be(key, 0) ^ FK[0];
     K[1] = load_u32_be(key, 1) ^ FK[1];
     K[2] = load_u32_be(key, 2) ^ FK[2];
@@ -191,6 +204,12 @@ void SM4_encrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks)
     uint32_t B2 = load_u32_be(in, 2);
     uint32_t B3 = load_u32_be(in, 3);
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+
     /*
      * Uses byte-wise sbox in the first and last rounds to provide some
      * protection from cache based side channels.
@@ -216,6 +235,12 @@ void SM4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks)
     uint32_t B1 = load_u32_be(in, 1);
     uint32_t B2 = load_u32_be(in, 2);
     uint32_t B3 = load_u32_be(in, 3);
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     SM4_RNDS(31, 30, 29, 28, SM4_T_slow);
     SM4_RNDS(27, 26, 25, 24, SM4_T);

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -59,6 +59,7 @@
 int WHIRLPOOL_Init(WHIRLPOOL_CTX *c)
 {
     if (FIPS_mode()) {
+        memset(c, 0, sizeof(*c));
         FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
         return 0;
     }

--- a/crypto/whrlpool/wp_dgst.c
+++ b/crypto/whrlpool/wp_dgst.c
@@ -58,6 +58,10 @@
 
 int WHIRLPOOL_Init(WHIRLPOOL_CTX *c)
 {
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        return 0;
+    }
     memset(c, 0, sizeof(*c));
     return 1;
 }
@@ -71,6 +75,12 @@ int WHIRLPOOL_Update(WHIRLPOOL_CTX *c, const void *_inp, size_t bytes)
      */
     size_t chunk = ((size_t)1) << (sizeof(size_t) * 8 - 4);
     const unsigned char *inp = _inp;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
 
     while (bytes >= chunk) {
         WHIRLPOOL_BitUpdate(c, inp, chunk * 8);
@@ -89,6 +99,12 @@ void WHIRLPOOL_BitUpdate(WHIRLPOOL_CTX *c, const void *_inp, size_t bits)
     unsigned int bitoff = c->bitoff,
         bitrem = bitoff % 8, inpgap = (8 - (unsigned int)bits % 8) & 7;
     const unsigned char *inp = _inp;
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
 
     /*
      * This 256-bit increment procedure relies on the size_t being natural
@@ -211,6 +227,12 @@ int WHIRLPOOL_Final(unsigned char *md, WHIRLPOOL_CTX *c)
     size_t i, j, v;
     unsigned char *p;
 
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 1;
+    }
+
     bitoff %= 8;
     if (bitoff)
         c->data[byteoff] |= 0x80 >> bitoff;
@@ -248,6 +270,12 @@ unsigned char *WHIRLPOOL(const void *inp, size_t bytes, unsigned char *md)
 {
     WHIRLPOOL_CTX ctx;
     static unsigned char m[WHIRLPOOL_DIGEST_LENGTH];
+
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return NULL;
+    }
 
     if (md == NULL)
         md = m;

--- a/crypto/whrlpool/wp_local.h
+++ b/crypto/whrlpool/wp_local.h
@@ -7,6 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+# include "openssl/opensslconf.h"
+
+#ifdef OPENSSL_FIPS
+# include "openssl/fips.h"
+# include "openssl/err.h"
+#endif
+
 #include <openssl/whrlpool.h>
 
 void whirlpool_block(WHIRLPOOL_CTX *, const void *, size_t);

--- a/include/crypto/md32_common.h
+++ b/include/crypto/md32_common.h
@@ -132,6 +132,14 @@ int HASH_UPDATE(HASH_CTX *c, const void *data_, size_t len)
     HASH_LONG l;
     size_t n;
 
+#if defined(FIPS_HASH_DISABLE)
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
+#endif
+
     if (len == 0)
         return 1;
 
@@ -185,6 +193,13 @@ int HASH_UPDATE(HASH_CTX *c, const void *data_, size_t len)
 
 void HASH_TRANSFORM(HASH_CTX *c, const unsigned char *data)
 {
+#if defined(FIPS_HASH_DISABLE)
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return;
+    }
+#endif
     HASH_BLOCK_DATA_ORDER(c, data, 1);
 }
 
@@ -192,6 +207,14 @@ int HASH_FINAL(unsigned char *md, HASH_CTX *c)
 {
     unsigned char *p = (unsigned char *)c->data;
     size_t n = c->num;
+
+#if defined(FIPS_HASH_DISABLE)
+    if (FIPS_mode()) {
+        FIPSerr(ERR_LIB_FIPS, FIPS_R_NON_FIPS_METHOD);
+        OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");
+        return 0;
+    }
+#endif
 
     p[n] = 0x80;                /* there is always room for one */
     n++;


### PR DESCRIPTION
Here is an updated version of the code that was reviewed yesterday by Solar and Maple.

The changes from that branch are the following:

1). For any FIPS unapproved algorithm that returns an error code on initialization, eg. 'int MD4_Init(), this code returns an error code on initialization and sets an internal error state which can be queried to determine if a FIPS unapproved algorithm was called.

2). Any attempt to use a FIPS unapproved algorithm that reported an error code on initialization will abort the program using:
```OpenSSLDie(__FILE__, __LINE__, "FATAL FIPS Unapproved algorithm called");```

eg. Calling any of MD4_Update() / MD4_Transform() / MD4_Final() after MD4_Init() returned a failure code will abort the calling program. Calling MD4_Update() / MD4_Transform() / MD4_Final() without calling MD4_Init() always aborts of course.

3). For any FIPS unapproved algorithm that does not return an error code on initialization. eg. Blowfish 'void BF_set_key()', or 'void IDEA_set_encrypt_key()' calling any initialization operation will immediately abort the calling program using OpenSSLDie(...as above..).

4). Any attempt to use a FIPS unapproved algorithm in any way that would transform data (i.e. any encrypt/decrypt/sign/verify/hash/message digest operations) will immediately abort the calling program using OpenSSLDie(...as above..). eg. 'void des_encrypt()' or 'void IDEA_cbc_encrypt()', or 'MD5_Update()'.

Note - this is for the underlying direct access algorithm functions. Normally, users of openssl create an instance of an algorithm by calling an instantiation function eg. EVP_md4(). All attempt to instantiate unapproved algorithms return NULL, thus disallowing access to the underlying algorithm via a returned openssl context pointer.

I believe this allows openssl to "fail safely" in the case of using FIPS unapproved algorithms, and not allow any calling application to believe it has successfully either instantiated an unapproved algorithm, or successfully used an unapproved algorithm to transform data in any way.
