### PR TITLE
Debug mode, plus extraction, tarball creation, and artifact uploading

### DIFF
--- a/.github/workflows/fipsmodule.yml
+++ b/.github/workflows/fipsmodule.yml
@@ -1,24 +1,63 @@
 name: Build OpenSSL FIPS module
 
 on:
-    push:
-    pull_request:
-        branches: [ dist-git ]
+  push:
+  pull_request:
+    branches: [dist-git]
 
 jobs:
-    mockBuild:
-        runs-on: ubuntu-latest
-        container:
-            image: quay.io/rockylinux/rockylinux:9
-            options: --privileged
-        steps:
-            - uses: actions/checkout@v3
-            - name: Build openssl rpm
-              run: |
-                echo "Installing mock"
-                dnf -y install epel-release
-                dnf -y install mock rpm-build
-                echo "Running mock build"
-                mock -r .mock-config/rocky-lts92-x86_64.cfg --spec="./SPECS/openssl.spec" --sources="./SOURCES"
-                echo "Extracting FIPS module from RPM"
-                
+  mockBuild:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/rockylinux/rockylinux:9
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build openssl rpm
+        run: |
+          unset DEBUG
+          mkdir -p RESULTS
+          if [ -z "$DEBUG" ]; then
+              echo "Installing mock"
+              dnf -y install epel-release
+              dnf -y install mock rpm-build
+              echo "Running mock build"
+              mock -v -r .mock-config/rocky-lts92-x86_64.cfg \
+                --spec="./SPECS/openssl.spec" \
+                --sources="./SOURCES" \
+                --resultdir="./RESULTS"
+          else
+              set -x
+              set +e
+              touch RESULTS/openssl-libs-3.0.7-27.el9_2.ciqlts.0.2.1.x86_64.rpm
+              echo "Fake build log for your sprog" > RESULTS/build.log
+          fi
+          echo "Contents of result directory"
+          ls -l ./RESULTS
+          cat ./RESULTS/build.log
+
+          # Extract the FIPS module
+          mkdir RESULTS/fipsmodule
+          cd RESULTS/fipsmodule
+          if [ -z "$DEBUG" ]; then
+              echo "Extracting FIPS module"
+              rpm2cpio ../openssl-libs-3*ciqlts*.x86_64.rpm | cpio -idmv ./usr/lib64/\*/fips.so
+          else
+              mkdir -p usr/lib64/ossl-modules
+              echo Creating fake fips module
+              touch usr/lib64/ossl-modules/fips.so
+          fi
+          RPMVERSION=$(ls ../openssl-libs-3*ciqlts*.x86_64.rpm | sed -e 's/.*openssl-libs-\(3.*\)\.rpm/\1/')
+          echo "Creating fips module tarball"
+          tar -czf ../fips_module_CIQ-${RPMVERSION}.tar.gz usr
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fips_module_RESULTS
+          path: |
+            RESULTS/*.log
+            RESULTS/*.rpm
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fips_module_tarball
+          path: RESULTS/*.tar.gz

--- a/.mock-config/rocky-lts92-x86_64.cfg
+++ b/.mock-config/rocky-lts92-x86_64.cfg
@@ -1,6 +1,6 @@
 # Generic Mock config for building against stock Rocky 9.2 on x86_64
 # It includes baseos/appstream/crb, along with the devel repo enabled by default
-# 
+#
 # This should allow your local builds to match what the Peridot LTS builds are doing
 #
 
@@ -9,8 +9,10 @@ config_opts['dist'] = 'el9_2.ciqlts'  # only useful for --resultdir variable sub
 config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:9'
-config_opts['description'] = 'Rocky Linux 9'
+# Don't build a bootstrap image, this is a one and done, so a cache would not be used
+config_opts['use_bootstrap_image'] = False
+#config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:9'
+config_opts['description'] = 'Rocky Linux 9.2 LTS by CIQ'
 
 config_opts['macros']['%dist'] = '.el9_2.ciqlts'
 


### PR DESCRIPTION
I can't commit to the repo, so here's a PR.

This creates two artifacts, the RESULTS dir logs and rpms, and the fips module tarball:

If you download the fips module tarball you get a file: fips_module_tarball.zip

```
$  openssl git:(test-gh-actions) unzip  ~/Downloads/fips_module_tarball.zip                                                                                                                                                          
Archive:  /home/jtate/Downloads/fips_module_tarball.zip
  inflating: fips_module_CIQ-3.0.7-27.el9_2.ciqlts.0.2.1.x86_64.tar.gz  
$  openssl git:(test-gh-actions) tar -tzf fips_module_CIQ-3.0.7-27.el9_2.ciqlts.0.2.1.x86_64.tar.gz                                                                                                                               
usr/
usr/lib64/
usr/lib64/ossl-modules/
usr/lib64/ossl-modules/fips.so
```